### PR TITLE
refactor: put manami offline db in its own manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@kfang/typescript-fp": "^1.26.0",
     "axios": "^1.7.3",
     "node-html-parser": "^6.1.13"
   }

--- a/src/index.mts
+++ b/src/index.mts
@@ -4,8 +4,7 @@ import path from "path";
 import fsp from "fs/promises";
 import fs from "fs";
 import { QBitorrentManager } from './qbitorrent.mjs';
-import { ManamiManager } from './manami/manami.manager.mjs';
-import { AnimeOfflineDbEntry } from './manami/manami.models.mjs';
+import { ManamiManager, AnimeOfflineDbEntry } from './manami/index.mjs';
 
 const MANAMI_CACHE_FILE = "./anime-offline-database.json";
 const MANAMI_DOWNLOAD_URL = "https://raw.githubusercontent.com/manami-project/anime-offline-database/master/anime-offline-database-minified.json";
@@ -90,7 +89,6 @@ async function main(): Promise<void> {
     console.log("initialized qbittorrent manager");
 
     const root = "/mnt/f/Weaboo/";
-
     const hashToAnime: Record<string, AnimeOfflineDbEntry> = {};
     
     for (const search of searches) {

--- a/src/manami/index.mts
+++ b/src/manami/index.mts
@@ -1,0 +1,3 @@
+export { AnimeOfflineDbEntryNotFound } from "./manami.errors.mjs";
+export { IManamiMangerOpts, ManamiManager } from "./manami.manager.mjs";
+export { AnimeOfflineDbEntry } from "./manami.models.mjs";

--- a/src/manami/manami.errors.mts
+++ b/src/manami/manami.errors.mts
@@ -1,0 +1,5 @@
+export class AnimeOfflineDbEntryNotFound extends Error {
+    constructor(public readonly anidbId: string) {
+        super("AnimeOfflineDbEntry was not found");
+    }
+}

--- a/src/manami/manami.manager.mts
+++ b/src/manami/manami.manager.mts
@@ -1,0 +1,49 @@
+import axios from "axios";
+import fs from "fs/promises";
+import { AnimeOfflineDbEntry, IAnimeOfflineDb } from "./manami.models.mjs";
+import {TryAsync} from "@kfang/typescript-fp";
+import { AnimeOfflineDbEntryNotFound } from "./manami.errors.mjs";
+
+export interface IManamiMangerOpts {
+    downloadUrl: string;
+    cacheFilePath: string;
+}
+
+// TODO: This should go into a SQLite db
+export class ManamiManager {
+
+    public static async build(opts: IManamiMangerOpts): Promise<ManamiManager> {
+        let db: IAnimeOfflineDb = { lastUpdate: "", data: [] };
+        
+        try {
+            const cached = await fs.readFile(opts.cacheFilePath);
+            db = JSON.parse(cached.toString());
+        } catch (e) {
+            const response = await axios.get<IAnimeOfflineDb>(opts.downloadUrl);
+            await fs.writeFile(opts.cacheFilePath, JSON.stringify(response.data));
+            db = response.data;
+        }
+
+        return new ManamiManager(db);
+    }
+
+    private readonly entries: Record<string, AnimeOfflineDbEntry>;
+    
+    private constructor(db: IAnimeOfflineDb) {
+        this.entries = {};
+        for (const entry of db.data) {
+            const value = new AnimeOfflineDbEntry(entry);
+            const key = value.anidbId;
+            if (key) {
+                this.entries[key] = value;
+            }
+        }
+
+        this.getEntryByAnidbId = this.getEntryByAnidbId.bind(this);
+    }
+
+    public getEntryByAnidbId(anidbId: string): TryAsync<AnimeOfflineDbEntry> {
+        const entry = this.entries[anidbId];
+        return entry ? TryAsync.success(entry) : TryAsync.failure(new AnimeOfflineDbEntryNotFound(anidbId));
+    }
+}

--- a/src/manami/manami.models.mts
+++ b/src/manami/manami.models.mts
@@ -1,9 +1,3 @@
-import axios from "axios";
-import fs from "fs";
-
-const CACHE_FILE = "./anime-offline-database.json";
-const animeOfflineDbUrl = "https://raw.githubusercontent.com/manami-project/anime-offline-database/master/anime-offline-database-minified.json";
-
 export interface IAnimeOfflineDbEntry {
     readonly animeSeason: {
         readonly season: "SPRING" | "SUMMER" | "FALL" | "WINTER" | "UNDEFINED";
@@ -52,25 +46,4 @@ export class AnimeOfflineDbEntry {
     get folderName(): string {
         return `${this.title} [anidb3-${this.anidbId}]`;
     }
-}
-
-export async function getAnimeOfflineDb(): Promise<Record<string, AnimeOfflineDbEntry>> {
-    if (!fs.existsSync(CACHE_FILE)) {
-        const response = await axios.get<IAnimeOfflineDb>(animeOfflineDbUrl);
-        fs.writeFileSync(CACHE_FILE, JSON.stringify(response.data));
-    }
-
-    const db = JSON.parse(fs.readFileSync(CACHE_FILE).toString()) as IAnimeOfflineDb;
-
-    const entries: Record<string, AnimeOfflineDbEntry> = {};
-    for (const entry of db.data) {
-        const value = new AnimeOfflineDbEntry(entry);
-        const key = value.anidbId;
-
-        if (key) {
-            entries[key] = value;
-        }
-    }
-
-    return entries;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@kfang/typescript-fp@npm:^1.26.0":
+  version: 1.26.0
+  resolution: "@kfang/typescript-fp@npm:1.26.0"
+  checksum: 10c0/c850e5daa1f9907ce793309a47d5439c82ce8522a3b093f1861ae1c193c4497409b4cad9b25ca36c00b7cd1ab4a86dfdd083f2303c989bdcc7010bd2db2c4f59
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:^20.0.0":
   version: 20.16.1
   resolution: "@types/node@npm:20.16.1"
@@ -196,6 +203,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@kfang/typescript-fp": "npm:^1.26.0"
     "@types/node": "npm:^20.0.0"
     axios: "npm:^1.7.3"
     node-html-parser: "npm:^6.1.13"


### PR DESCRIPTION
- puts code related to manami into its own manager
- switch to using `@kfang/typescript-fp`